### PR TITLE
fixed typo in Octopus bootstrap script

### DIFF
--- a/bootstrap_octopus_deploy.sh
+++ b/bootstrap_octopus_deploy.sh
@@ -7,7 +7,7 @@ export FFFS_WEB_PORTAL_GIS_DB_DATA_USERNAME='#{webPortalGisDbDataUsername}'
 export FFFS_WEB_PORTAL_GIS_DB_DATA_PASSWORD='#{webPortalGisDbDataPassword}'
 export FFFS_WEB_PORTAL_GIS_DB_READER_USERNAME='#{webPortalGisDbReaderUsername}'
 export FFFS_WEB_PORTAL_GIS_DB_READER_PASSWORD='#{webPortalGisDbReaderPassword}'
-export FFFS_WEB_PORTAL_GIS_SDE_PASSWORD='#{webPortalGisDbSdePassword}'
+export FFFS_WEB_PORTAL_GIS_DB_SDE_PASSWORD='#{webPortalGisDbSdePassword}'
 
 echo "Executing Maven DB script"
 mvn clean process-resources


### PR DESCRIPTION
pom.xml has FFFS_WEB_PORTAL_GIS_DB_SDE_PASSWORD
However bootstrap_octopus_deploy.sh has;
FFFS_WEB_PORTAL_GIS_SDE_PASSWORD

Which is incorrect and needs to be updated.

